### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Microsoft OneDrive
 
-Publisher: Splunk \
-Connector Version: 2.4.0 \
-Product Vendor: Microsoft \
-Product Name: Microsoft OneDrive \
+Publisher: Splunk <br>
+Connector Version: 2.4.0 <br>
+Product Vendor: Microsoft <br>
+Product Name: Microsoft OneDrive <br>
 Minimum Product Version: 6.2.2
 
 This app integrates with Microsoft OneDrive to execute various generic actions
@@ -86,20 +86,20 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[get file](#action-get-file) - Download a file from server and add it to the vault \
-[list items](#action-list-items) - List of items \
-[list drive](#action-list-drive) - List of Drives \
-[upload file](#action-upload-file) - Upload file \
-[delete file](#action-delete-file) - Delete file \
-[delete folder](#action-delete-folder) - Delete a folder \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[get file](#action-get-file) - Download a file from server and add it to the vault <br>
+[list items](#action-list-items) - List of items <br>
+[list drive](#action-list-drive) - List of Drives <br>
+[upload file](#action-upload-file) - Upload file <br>
+[delete file](#action-delete-file) - Delete file <br>
+[delete folder](#action-delete-folder) - Delete a folder <br>
 [create folder](#action-create-folder) - Create a folder
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -114,7 +114,7 @@ No Output
 
 Download a file from server and add it to the vault
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -146,7 +146,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List of items
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -209,7 +209,7 @@ action_result.parameter.ph_0 | ph | | |
 
 List of Drives
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -249,7 +249,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Upload file
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -312,7 +312,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Delete file
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -341,7 +341,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Delete a folder
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -371,7 +371,7 @@ action_result.parameter.ph_0 | ph | | |
 
 Create a folder
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters

--- a/microsoftonedrive.json
+++ b/microsoftonedrive.json
@@ -19,7 +19,7 @@
     ],
     "license": "Copyright (c) 2019-2025 Splunk Inc.",
     "app_version": "2.4.0",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "Cloud v19.192.0926.0012"

--- a/microsoftonedrive.json
+++ b/microsoftonedrive.json
@@ -1863,5 +1863,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)